### PR TITLE
Provide support for other HTTP methods, headers, and body content

### DIFF
--- a/src/OAuthClient.js
+++ b/src/OAuthClient.js
@@ -346,7 +346,9 @@ OAuthClient.prototype.makeApiCall = function makeApiCall(params) {
     };
 
     if (params.headers && typeof params.headers === 'object') {
-      request.headers = { ...request.headers, ...params.headers };
+      for (const header in params.headers) {
+        request.headers[header] = params.headers[header];
+      }
     }
 
     params.body && (request.body = params.body);

--- a/src/OAuthClient.js
+++ b/src/OAuthClient.js
@@ -337,13 +337,19 @@ OAuthClient.prototype.makeApiCall = function makeApiCall(params) {
 
     const request = {
       url: params.url,
-      method: 'GET',
+      method: params.method || 'GET',
       headers: {
         Authorization: `Bearer ${this.getToken().access_token}`,
         Accept: AuthResponse._jsonContentType,
         'User-Agent': OAuthClient.user_agent,
       },
     };
+
+    if (params.headers && typeof params.headers === 'object') {
+      request.headers = { ...request.headers, ...params.headers };
+    }
+
+    params.body && (request.body = params.body);
 
     resolve(this.getTokenRequest(request));
   }))).then((authResponse) => {


### PR DESCRIPTION
Added support for POST, PUT, DELETE, etc as well as body content and HTTP headers. Changes make no assumptions about the type of headers and body content passed in, up to the user to send correct headers and format body appropriately.

Example:

```js
// Body sample from API explorer examples
const body = {
  TrackQtyOnHand: true,
  Name: "Garden Supplies",
  QtyOnHand: 10,
  InvStartDate: "2015-01-01",
  Type: "Inventory",
  IncomeAccountRef: {
    name: "Sales of Product Income",
    value: "79"
  },
  AssetAccountRef: {
    name: "Inventory Asset",
    value: "81"
  },
  ExpenseAccountRef: {
    name: "Cost of Goods Sold",
    value: "80"
  }
};

const res = await client.makeApiCall({
  url: 'https://sandbox-quickbooks.api.intuit.com/v3/company/1234/item',
  method: 'POST',
  headers: {
    'Content-Type': 'application/json'
  },
  body: JSON.stringify(body)
});
```