### PR TITLE
Add more code coverage for OAuthClient

### DIFF
--- a/test/OAuthClientTest.js
+++ b/test/OAuthClientTest.js
@@ -262,7 +262,7 @@ describe('Tests for OAuthClient', () => {
   });
 
   // make API Call
-  describe('Make API Call ', () => {
+  describe('Make API Call', () => {
     before(() => {
       nock('https://sandbox-quickbooks.api.intuit.com').persist()
         .get('/v3/company/12345/companyinfo/12345')
@@ -403,15 +403,6 @@ describe('Validate Id Token ', () => {
     oauthClient.validateIdToken()
       .then((response) => {
         expect(response).to.be.equal(expectedOpenIDToken);
-      });
-  });
-});
-
-describe('Get key from JWK URI', () => {
-  it('getKeyFromJWKsURI', () => {
-    oauthClient.getKeyFromJWKsURI()
-      .then((response) => {
-        expect(response).not.to.be.null;
       });
   });
 });

--- a/test/OAuthClientTest.js
+++ b/test/OAuthClientTest.js
@@ -285,6 +285,20 @@ describe('Tests for OAuthClient', () => {
             .to.be.equal(JSON.stringify(expectedMakeAPICall));
         });
     });
+    it('Make API Call in Sandbox Environment with headers as parameters', () => {
+      oauthClient.getToken().realmId = '12345';
+      // eslint-disable-next-line no-useless-concat
+      return oauthClient.makeApiCall({
+          url: 'https://sandbox-quickbooks.api.intuit.com/v3/company/' + '12345' + '/companyinfo/' + '12345',
+          headers: {
+            Accept: "application/json",
+          }
+        })
+        .then((authResponse) => {
+          expect(JSON.stringify(authResponse.getJson()))
+            .to.be.equal(JSON.stringify(expectedMakeAPICall));
+        });
+    });
     it('loadResponseFromJWKsURI', () => {
       const request = {
         url: 'https://sandbox-quickbooks.api.intuit.com/v3/company/12345/companyinfo/12345',
@@ -474,6 +488,10 @@ describe('Generate OAuth1Sign', () => {
 
     const oauth1Sign = oauthClient.generateOauth1Sign(params);
     expect(oauth1Sign).to.be.a('String');
+    expect(oauth1Sign).to.have.string('oauth_consumer_key="qyprdFsHNQtdRupMKmYnDt6MOjWBW9');
+    expect(oauth1Sign).to.have.string('oauth_nonce="nonce');
+    expect(oauth1Sign).to.have.string('oauth_version="1.0');
+    expect(oauth1Sign).to.have.string('oauth_token', 'oauth_timestamp', 'oauth_signature');
   });
 });
 

--- a/test/OAuthClientTest.js
+++ b/test/OAuthClientTest.js
@@ -407,6 +407,15 @@ describe('Validate Id Token ', () => {
   });
 });
 
+describe('Get key from JWK URI', () => {
+  it('getKeyFromJWKsURI', () => {
+    oauthClient.getKeyFromJWKsURI()
+      .then((response) => {
+        expect(response).not.to.be.null;
+      });
+  });
+});
+
 // Validate Refresh Token
 describe('Validate Refresh Token', () => {
   it('Validate should handle expired token', () => {


### PR DESCRIPTION
# Improved test code coverage

## Changes
Updated `OAuthClientTest` include a test case for `makeApiCall` with parameters, and updated test for `generateOauth1Sign` to be more precise.

![Screen Shot 2019-10-18 at 11 48 30 AM](https://user-images.githubusercontent.com/2584959/67120024-40277d00-f19d-11e9-8f4d-9d76dbfca802.png)

## Notes
I have another set of changes coming with more coverage for `OAuthClientTest1`