### PR TITLE
add state from callback response to returned token

### DIFF
--- a/src/OAuthClient.js
+++ b/src/OAuthClient.js
@@ -135,6 +135,7 @@ OAuthClient.prototype.createToken = function createToken(uri) {
     if (!uri) throw new Error('Provide the Uri');
     const params = queryString.parse(uri.split('?').reverse()[0]);
     this.getToken().realmId = (params.realmId ? params.realmId : '');
+    if ('state' in params) this.getToken().state = params.state;
 
     const body = {};
     if (params.code) {


### PR DESCRIPTION
According to the [OAuth 2.0 documentation](https://developer.intuit.com/app/developer/qbo/docs/develop/authentication-and-authorization/oauth-2.0#step-4-handle-the-oauth-2-0-server-response) "state" that may (and should) be provided in code request would be returned in QuickBooks code callback