### PR TITLE
Accept Full Range of HTTP Success Codes

### DIFF
--- a/src/response/AuthResponse.js
+++ b/src/response/AuthResponse.js
@@ -86,7 +86,7 @@ AuthResponse.prototype.headers = function headers() {
  * @returns {*|boolean}
  */
 AuthResponse.prototype.valid = function valid() {
-  return (this.response && Number(this.response.status) === 200);
+  return (this.response && Number(this.response.status) >= 200 && Number(this.response.status) < 300);
 };
 
 


### PR DESCRIPTION
I noticed as I was using this package that the Intuit Payment API in particular doesn't always respond with 200 status codes. Currently, this package is written to only consider 200 codes successful, so to prevent my code from breaking, I needed the client to accept any status that would normally count as a "success" as valid. I've modified the single line validity check to accept anything within the 2XX range. 