### PR TITLE
[Issue102][Hacktoberfest] unit test to validate typings definition file

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "clean-install": "rm -rf node_modules && npm install",
     "snyk-protect": "snyk protect",
     "prepublish": "npm run snyk-protect",
-    "test-ts": "mocha -r ts-node/register test/**/*.test.ts",
-    "coverage": "nyc -r lcov -e .ts -x \"*.test.ts\" npm run test"
+    "test-ts": "mocha -r ts-node/register test/**/*.test.ts"
   },
   "keywords": [
     "intuit-oauth",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "node index.js",
     "karma": "karma start karma.conf.js",
-    "test": "nyc mocha",
+    "test": "nyc mocha && npm run test-ts",
     "snyk": "snyk test",
     "lint": "eslint .",
     "fix": "eslint . --fix",
@@ -17,7 +17,9 @@
     "show-coverage": "npm test; open -a 'Google Chrome' coverage/index.html",
     "clean-install": "rm -rf node_modules && npm install",
     "snyk-protect": "snyk protect",
-    "prepublish": "npm run snyk-protect"
+    "prepublish": "npm run snyk-protect",
+    "test-ts": "mocha -r ts-node/register test/**/*.test.ts",
+    "coverage": "nyc -r lcov -e .ts -x \"*.test.ts\" npm run test"
   },
   "keywords": [
     "intuit-oauth",
@@ -77,6 +79,8 @@
     "winston": "^3.1.0"
   },
   "devDependencies": {
+    "@types/chai": "^4.2.14",
+    "@types/mocha": "^8.0.3",
     "btoa": "^1.2.1",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
@@ -89,7 +93,9 @@
     "nyc": "^15.0.1",
     "prettier": "^2.0.5",
     "sinon": "^9.0.2",
-    "snyk": "^1.316.1"
+    "snyk": "^1.316.1",
+    "ts-node": "^9.0.0",
+    "typescript": "^4.0.3"
   },
   "snyk": true
 }

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -1,0 +1,92 @@
+'use strict';
+import { expect } from 'chai';
+import * as OAuthClient from '../src/OAuthClient';
+
+const AuthResponse = require('../src/response/AuthResponse');
+
+describe('OAuthClient type validation tests', () => {
+    let oAuthClientConfig;
+
+    beforeEach(() => {
+        oAuthClientConfig = {
+            clientId: 'clientId',
+            clientSecret: 'clientSecret',
+            environment: 'sandbox',
+            redirectUri: 'http://localhost:8000/callback'
+    };
+    });
+
+    it('environment should have appropriate fields and types', () => {
+        const result = OAuthClient.environment;
+        expect(typeof result).to.equal('object');
+        expect(result.sandbox).to.equal('https://sandbox-quickbooks.api.intuit.com/');
+        expect(result.xyz).to.be.undefined;
+    });
+
+    it('scopes should have appropriate fields and types', () => {
+        const result = OAuthClient.scopes;
+        expect(typeof result).to.equal('object');
+        expect(result.Accounting).to.equal('com.intuit.quickbooks.accounting');
+        expect(typeof result.Accounting).to.equal('string');
+        expect(result.accounting).to.be.undefined;
+    });
+
+    it('OAuthClientConfig should have appropriate fields and types', () => {
+        expect(typeof oAuthClientConfig.clientId).to.equal('string');
+        expect(typeof oAuthClientConfig.clientSecret).to.equal('string');
+        expect(typeof oAuthClientConfig.environment).to.equal('string');
+        expect(typeof oAuthClientConfig.redirectUri).to.equal('string');
+    });
+
+    it('Should create OAuthClient with appropriate fields and types for valid OAuthClientConfig', () => {
+        const oAuthClient = new OAuthClient({
+            oAuthClientConfig
+        });
+        expect(typeof oAuthClient).to.equal('object');
+        expect(typeof oAuthClient.token).to.equal('object');
+        expect(typeof oAuthClient.logging).to.equal('boolean');
+        expect(typeof oAuthClient.logger).to.equal('object');
+        expect(typeof oAuthClient.state).to.equal('object');
+    });
+
+    it('should create new access token instance with appropriate fields and types for valid OAuthClient', () => {
+        const oAuthClient = new OAuthClient({
+            oAuthClientConfig
+        });
+        const accessToken = oAuthClient.getToken();
+        expect(typeof accessToken).to.equal('object');
+        expect(typeof accessToken.realmId).to.equal('string');
+        expect(typeof accessToken.token_type).to.equal('string');
+        expect(typeof accessToken.refresh_token).to.equal('string');
+        expect(typeof accessToken.expires_in).to.equal('number');
+        expect(typeof accessToken.x_refresh_token_expires_in).to.equal('number');
+        expect(typeof accessToken.id_token).to.equal('string');
+        expect(typeof accessToken.latency).to.equal('number');
+        expect(typeof accessToken.createdAt).to.equal('number');
+    });
+
+    it('should create new auth response instance with appropriate fields and types for valid accessToken', () => {
+        const oAuthClient = new OAuthClient({
+            oAuthClientConfig
+        });
+        const accessToken = oAuthClient.getToken();
+        const authResponse = new AuthResponse({ token: accessToken });
+        expect(typeof authResponse.token).to.equal('object');
+        expect(typeof authResponse.response).to.equal('string');
+        expect(typeof authResponse.body).to.equal('string');
+        expect(typeof authResponse.json).to.equal('object');
+        expect(typeof authResponse.intuit_tid).to.equal('string');
+    });
+
+    it('Should create OAuthClientError with appropriate fields and types for empty authResponse', () => {
+        const oAuthClient = new OAuthClient({
+            oAuthClientConfig
+        });
+        const oAuthClientError = oAuthClient.createError(new Error(), null);
+        expect(typeof oAuthClientError.error).to.equal('string');
+        expect(typeof oAuthClientError.authResponse).to.equal('string');
+        expect(typeof oAuthClientError.intuit_tid).to.equal('string');
+        expect(typeof oAuthClientError.originalMessage).to.equal('string');
+        expect(typeof oAuthClientError.error_description).to.equal('string');
+    });
+});


### PR DESCRIPTION
Enum, Interface, Class defined in index.d.ts are the implementation details. Unit tests that validate the behavior of the enums already exists in test module. 
The changes in types.test.ts are only meant to test the types and whether the mandatory fields are returned or not.
Not the actual value returned by the fields.
This file doesn't add to the coverage as nothing is executable.

<img width="995" alt="Screen Shot 2020-10-22 at 2 35 32 AM" src="https://user-images.githubusercontent.com/73214669/96787404-4b943080-140f-11eb-9fef-24136e6f2fac.png">


