### PR TITLE
Release 4.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: node_js
 
 node_js:
-  - 9
-  - 8
+  - 10
+  - 11
+  - 12
+  - 14
 
 before_script:
   - npm install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,39 +1,137 @@
 # Changelog
 
-## [1.5.0](https://github.com/intuit/oauth-jsclient/releases/tag/1.5.0)
+## [3.0.2](https://github.com/intuit/oauth-jsclient/tree/3.0.2)
+#### Features 
+- [Added support for passing custom authorize URL's](https://github.com/intuit/oauth-jsclient/pull/92)
 
-- ES6 Standard Adoption 
+
+## [3.0.1](https://github.com/intuit/oauth-jsclient/tree/3.0.1)
+#### Issues Fixed
+- [`snyk` package as a dependency since the 3.0 version](https://github.com/intuit/oauth-jsclient/issues/88)
+
+## [3.0.0](https://github.com/intuit/oauth-jsclient/tree/3.0.0)
+#### Breaking Changes
+- Minimum Node Version >= 8 LTS
+#### Features 
+- Supports Minimum Node version 8 LTS and newer ( not backward compatible )
+- Moved lower node versions ( node 7, node 6 to 2.x.x and 1.x.x release respectively )
+  - node version 6 and lower refer to 1.x.x 
+  - node version 7 and lower refer to 2.x.x
+- Enhanced Code Coverage
+#### Issues Fixed
+- ES Lint issues fixed.
+- Vulnerabilities fixed.
+- [Error failing to create if response is missing headers](https://github.com/intuit/oauth-jsclient/issues/70)
+
+## [2.1.0](https://github.com/intuit/oauth-jsclient/tree/2.1.0)
+#### Features 
+- Accept Full Range of HTTP Success Codes
+- Handle not JSON content in response parsing
+- Dependency cleanup ( still pending. Opening an issue )
+#### Issues Fixed
+- [Accept Full Range of HTTP Success Codes](https://github.com/intuit/oauth-jsclient/pull/78)
+- [Fix: handle not JSON content in response parsing](https://github.com/intuit/oauth-jsclient/pull/59)
+
+## [2.0.2](https://github.com/intuit/oauth-jsclient/tree/2.0.2)
+#### Features 
+- Improved Code Coverage
+- README Corrections
+- Fixed npm package issues in 2.0.1
+
+## [2.0.1](https://github.com/intuit/oauth-jsclient/tree/2.0.1)
+#### Features 
+- Improved Code Coverage
+- README Corrections
+
+## [2.0.0](https://github.com/intuit/oauth-jsclient/tree/2.0.0)
+#### Breaking Changes
+- Minimum Node Version >= 7.0.0
+#### Features 
+- Supports Minimum Node version >=7.0.0 ( not backward compatible )
+- Support for HTTP methods for API calls other than GET
+- Enhanced Code Coverage
+- ES Lint issues fixed.
+#### Issues Fixed
+- [Does this library support any HTTP methods for API calls other than GET](https://github.com/intuit/oauth-jsclient/issues/40)
+- [Improve code coverage](https://github.com/intuit/oauth-jsclient/issues/39)
+- [Fix ESLint Issues](https://github.com/intuit/oauth-jsclient/issues/40)
+- [ngrok current version doesn't work](https://github.com/intuit/oauth-jsclient/issues/41)
+
+## [1.5.0](https://github.com/intuit/oauth-jsclient/releases/tag/1.5.0)
+#### Features
+Problem :
+- The csrf tokens created did not follow the singleton pattern.
+- Occasional use of strict mode keywords made the package usage difficult in ES6 compliant environments. 
+
+Solution :
+
+- csrf token instance created at the time of instantiating OAuthClient. Singleton JS design pattern adopted.
+- Adopted ES6 standardization
+- ESLint enabled
+#### Issues Fixed
+- [Strict mode keywords](https://github.com/intuit/oauth-jsclient/issues/4)
+- [csrf update to OAuthClient](https://github.com/intuit/oauth-jsclient/issues/30)
+
 
 ## [1.4.0](https://github.com/intuit/oauth-jsclient/releases/tag/1.4.0)
+#### Features
+Problem : 
+- The access-tokens are valid post the revoke() functionality.
 
+Solution : 
 - Clear Token Object on invoking revoke() functionality
 
-## [1.3.0](https://github.com/intuit/oauth-jsclient/releases/tag/1.3.0)
+#### Issues Fixed
+- [isAccessTokenValid() is true after calling revoke()](https://github.com/intuit/oauth-jsclient/issues/28)
 
+
+## [1.3.0](https://github.com/intuit/oauth-jsclient/releases/tag/1.3.0)
+#### Features
 - TokenValidation for Revoke functionality Fixed
+#### Issues Fixed
+- Release Updates
+- Revoke token [README.md](https://github.com/intuit/oauth-jsclient#revoke-access_token)
   
 ## [1.2.0](https://github.com/intuit/oauth-jsclient/releases/tag/1.2.0)
-
+#### Features
 - Highly Improved Implementation : setToken functionality  
+#### Issues Fixed
+1.) the setToken() and the constructor for passing the tokens are handled efficiently now.
+2.) [#20](https://github.com/intuit/oauth-jsclient/pull/20) and [#7](https://github.com/intuit/oauth-jsclient/pull/7) - Fixed
+3.) [#19](https://github.com/intuit/oauth-jsclient/issues/19) - HTTP 4XX Errors handled with more information.
 
 ## [1.1.3](https://github.com/intuit/oauth-jsclient/releases/tag/1.1.3)
-
+#### Features
 - Setting the Token methodology fixed
+#### Issues Fixed
+- [Error revoking token, this.token.refreshToken is not a function](https://github.com/intuit/oauth-jsclient/issues/16)
 
 ## [1.1.2](https://github.com/intuit/oauth-jsclient/releases/tag/1.1.2)
-
+#### Features
 - Supports Token Setting Functionality + New Scopes added
-
+- New scopes added :
+  - Payroll: com.intuit.quickbooks.payroll,
+  - TimeTracking: com.intuit.quickbooks.payroll.timetracking,
+  - Benefits: com.intuit.quickbooks.payroll.benefits,  
+#### Issues Fixed
+- [typo '/getCompanyInfo' in app.js](https://github.com/intuit/oauth-jsclient/issues/11)
+- [Console logging of tokens seems like a bad idea](https://github.com/intuit/oauth-jsclient/issues/13)
+  
 ## [1.1.1](https://github.com/intuit/oauth-jsclient/releases/tag/1.1.1)
 
 - Rolling Back changes to realmId field on createToken()
 
 ## [1.1.0](https://github.com/intuit/oauth-jsclient/releases/tag/1.1.0)
-
+#### Features
 - Support for passing realmId and id_token using setToken()
+#### Issues Fixed
+- Support for optionally passing realmId and id_token using setToken()
+- Issues fixed for #5
+- Issues fixed for #6
+- Issues fixed for #7
 
 ## [1.0.3](https://github.com/intuit/oauth-jsclient/releases/tag/1.0.3)
-
+#### Features 
 - Support for RefreshUsingToken method
 
 ## [1.0.2](https://github.com/intuit/oauth-jsclient/releases/tag/1.0.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [4.0.0](https://github.com/intuit/oauth-jsclient/tree/4.0.0)
+#### Breaking Changes
+- Minimum Node Version >= 10
+#### Features 
+- Supports Minimum Node version 10 and newer ( not backward compatible )
+- Moved lower node versions ( node 8,9, node 7, node 6 to 3.x.x. , 2.x.x and 1.x.x release respectively )
+  - node version 8,9 and higher refer to 3.x.x 
+  - node version 7 and higher refer to 2.x.x
+  - node version 6 and higher refer to 1.x.x
+#### Issues Fixed
+- [Adding Transport Override for PDF use case](https://github.com/intuit/oauth-jsclient/pull/98)
+
+#### References
+- [PDF Transport](https://github.com/intuit/oauth-jsclient/issues/97) 
+
 ## [3.0.2](https://github.com/intuit/oauth-jsclient/tree/3.0.2)
 #### Features 
 - [Added support for passing custom authorize URL's](https://github.com/intuit/oauth-jsclient/pull/92)

--- a/README.md
+++ b/README.md
@@ -441,6 +441,13 @@ oauthClient
 The client validates the ID Token and returns boolean `true` if validates successfully else it would
 throw an exception.
 
+#### Support for PDF format
+In order to save the PDF generated from the APIs properly, the correct transport type should be passed into the `makeAPI()`.Below is an example of the same:
+```
+.makeApiCall({ url: `${url}v3/company/${companyID}/invoice/${invoiceNumber}/pdf?minorversion=59` , headers:{'Content-Type': 'application/pdf','Accept':'application/pdf'}, transport: popsicle.createTransport({type: 'buffer'})})
+```
+The response is an actual buffer( binary BLOB) which could then be saved to the file. 
+
 ### Auth-Response
 
 The response provided by the client is a wrapped response of the below items which is what we call

--- a/README.md
+++ b/README.md
@@ -52,14 +52,15 @@ implementations which conforms to the specifications.
 
 # Requirements
 
-The Node.js client library is tested against the `Node 8 LTS` and newer versions.
+The Node.js client library is tested against the `Node 10` and newer versions.
 
-To use in node 6, please use
-[intuit-oauth@1.x.](https://github.com/intuit/oauth-jsclient/tree/1.5.0)
+| Version                                                                          | Node support                      |
+|----------------------------------------------------------------------------------|-----------------------------------|
+| [intuit-oauth@1.x.x](https://github.com/intuit/oauth-jsclient/tree/1.5.0)        | Node 6.x or higher                |
+| [intuit-oauth@2.x.x](https://github.com/intuit/oauth-jsclient/tree/2.0.0)        | Node 7.x or higher                |
+| [intuit-oauth@3.x.x](https://github.com/intuit/oauth-jsclient/tree/3.0.2)        | Node 8.x or Node 9.x and higher   |
 
-To use in node 7, please use
-[intuit-oauth@2.x.](https://github.com/intuit/oauth-jsclient/tree/2.0.0). Older node versions are
-not supported.
+**Note**: Older node versions are not supported.
 
 # Installation
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "intuit-oauth",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Intuit Node.js client for OAuth2.0 and OpenIDConnect",
   "main": "./src/OAuthClient.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "intuit-oauth",
-  "version": "3.0.3",
+  "version": "4.0.0",
   "description": "Intuit Node.js client for OAuth2.0 and OpenIDConnect",
   "main": "./src/OAuthClient.js",
   "scripts": {
@@ -51,7 +51,7 @@
     ]
   },
   "engines": {
-    "node": ">=8.17.0"
+    "node": ">=10"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "intuit-oauth",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Intuit Node.js client for OAuth2.0 and OpenIDConnect",
   "main": "./src/OAuthClient.js",
   "scripts": {

--- a/src/OAuthClient.js
+++ b/src/OAuthClient.js
@@ -383,7 +383,7 @@ OAuthClient.prototype.makeApiCall = function makeApiCall(params) {
               Accept: AuthResponse._jsonContentType,
               'User-Agent': OAuthClient.user_agent,
             },
-            params.headers,
+            params.headers
           )
         : Object.assign(
             {},
@@ -391,7 +391,7 @@ OAuthClient.prototype.makeApiCall = function makeApiCall(params) {
               Authorization: `Bearer ${this.getToken().access_token}`,
               Accept: AuthResponse._jsonContentType,
               'User-Agent': OAuthClient.user_agent,
-            },
+            }
           );
 
     const request = {

--- a/src/OAuthClient.js
+++ b/src/OAuthClient.js
@@ -372,6 +372,7 @@ OAuthClient.prototype.getUserInfo = function getUserInfo() {
 OAuthClient.prototype.makeApiCall = function makeApiCall(params) {
   return new Promise((resolve) => {
     params = params || {};
+    const transport = params.transport ? params.transport : popsicle.createTransport({ type: "text" });
 
     const headers =
       params.headers && typeof params.headers === 'object'
@@ -397,6 +398,7 @@ OAuthClient.prototype.makeApiCall = function makeApiCall(params) {
       url: params.url,
       method: params.method || 'GET',
       headers,
+      transport,
     };
 
     params.body && (request.body = params.body);

--- a/src/OAuthClient.js
+++ b/src/OAuthClient.js
@@ -108,6 +108,21 @@ OAuthClient.user_agent = `Intuit-OAuthClient-JS_${
   version.version
 }_${os.type()}_${os.release()}_${os.platform()}`;
 
+OAuthClient.prototype.setAuthorizeURLs = function setAuthorizeURLs(params) {
+  // check if the customURL's are passed correctly
+  if (!params) {
+    throw new Error("Provide the custom authorize URL's");
+  }
+  OAuthClient.authorizeEndpoint = params.authorizeEndpoint;
+  OAuthClient.tokenEndpoint = params.tokenEndpoint;
+  OAuthClient.revokeEndpoint = params.revokeEndpoint;
+  this.environment === 'sandbox'
+    ? (OAuthClient.userinfo_endpoint_sandbox = params.userInfoEndpoint)
+    : (OAuthClient.userinfo_endpoint_production = params.userInfoEndpoint);
+
+  return this;
+};
+
 /**
  * Redirect  User to Authorization Page
  * *


### PR DESCRIPTION
New Release Candidate: 4.0.0

#### Breaking Changes
- Minimum Node Version `>=` 10

#### Features 
- Supports Minimum Node version 10 and newer ( not backward compatible )
- Moved lower node versions ( node 8,9, node 7, node 6 to 3.x.x. , 2.x.x and 1.x.x release respectively )
  - node version 8,9 and higher refer to 3.x.x 
  - node version 7 and higher refer to 2.x.x
  - node version 6 and higher refer to 1.x.x
#### Issues Fixed
- [Adding Transport Override for PDF use case](https://github.com/intuit/oauth-jsclient/pull/98)

#### References
- [PDF Transport](https://github.com/intuit/oauth-jsclient/issues/97) 
