### PR TITLE
Continue Axios Migration

### DIFF
--- a/src/OAuthClient.js
+++ b/src/OAuthClient.js
@@ -182,8 +182,8 @@ OAuthClient.prototype.createToken = function createToken(uri) {
     resolve(this.getTokenRequest(request));
   })
     .then((res) => {
-      const authResponse = res.json ? res : null;
-      const json = (authResponse && authResponse.getJson()) || res;
+      const { response, ...authResponse } = res.json ? res : null;
+      const json = (authResponse && authResponse.json) || res;
       this.token.setToken(json);
       this.log('info', 'Create Token response is : ', JSON.stringify(authResponse, null, 2));
       return authResponse;

--- a/src/OAuthClient.js
+++ b/src/OAuthClient.js
@@ -169,7 +169,7 @@ OAuthClient.prototype.createToken = function createToken(uri) {
 
     const request = {
       url: OAuthClient.tokenEndpoint,
-      body,
+      data: body,
       method: 'POST',
       headers: {
         Authorization: `Basic ${this.authHeader()}`,
@@ -383,7 +383,7 @@ OAuthClient.prototype.makeApiCall = function makeApiCall(params) {
               Accept: AuthResponse._jsonContentType,
               'User-Agent': OAuthClient.user_agent,
             },
-            params.headers
+            params.headers,
           )
         : Object.assign(
             {},
@@ -391,7 +391,7 @@ OAuthClient.prototype.makeApiCall = function makeApiCall(params) {
               Authorization: `Bearer ${this.getToken().access_token}`,
               Accept: AuthResponse._jsonContentType,
               'User-Agent': OAuthClient.user_agent,
-            }
+            },
           );
 
     const request = {
@@ -552,7 +552,7 @@ OAuthClient.prototype.validateToken = function validateToken() {
  * @returns response
  */
 OAuthClient.prototype.loadResponse = function loadResponse(request) {
-  return axios.get(request).then((response) => response);
+  return axios(request).then((response) => response);
 };
 
 /**

--- a/src/response/AuthResponse.js
+++ b/src/response/AuthResponse.js
@@ -44,8 +44,8 @@ function AuthResponse(params) {
  */
 AuthResponse.prototype.processResponse = function processResponse(response) {
   this.response = response || '';
-  this.body = (response && response.body) || '';
-  this.json = this.body && this.isJson() ? JSON.parse(this.body) : null;
+  this.body = (response && response.data) || '';
+  this.json = this.body && this.isJson() ? this.body : null;
   this.intuit_tid = (response && response.headers && response.headers.intuit_tid) || '';
 };
 
@@ -57,7 +57,6 @@ AuthResponse.prototype.processResponse = function processResponse(response) {
 AuthResponse.prototype.getToken = function getToken() {
   return this.token.getToken();
 };
-
 
 /**
  * Get Token
@@ -92,10 +91,8 @@ AuthResponse.prototype.headers = function headers() {
  * @returns {*|boolean}
  */
 AuthResponse.prototype.valid = function valid() {
-  return (this.response && Number(this.response.status) >= 200
-    && Number(this.response.status) < 300);
+  return this.response && Number(this.response.status) >= 200 && Number(this.response.status) < 300;
 };
-
 
 /**
  * Get Json () { returns token as JSON }
@@ -119,7 +116,6 @@ AuthResponse.prototype.get_intuit_tid = function get_intuit_tid() {
   return this.intuit_tid;
 };
 
-
 /**
  * isContentType
  * *
@@ -135,7 +131,7 @@ AuthResponse.prototype.isContentType = function isContentType(contentType) {
  * @returns {string} getContentType
  */
 AuthResponse.prototype.getContentType = function getContentType() {
-  return this.response.get(AuthResponse._contentType) || '';
+  return this.response.headers[AuthResponse._contentType] || '';
 };
 
 /**
@@ -147,10 +143,8 @@ AuthResponse.prototype.isJson = function isJson() {
   return this.isContentType('application/json');
 };
 
-
-AuthResponse._contentType = 'Content-Type';
+AuthResponse._contentType = 'content-type';
 AuthResponse._jsonContentType = 'application/json';
 AuthResponse._urlencodedContentType = 'application/x-www-form-urlencoded';
-
 
 module.exports = AuthResponse;


### PR DESCRIPTION
Fixes: #143

Axios is not a drop-in replacement for Popsicle. Here are a few of the API differences:
- [Request config](https://axios-http.com/docs/req_config):
  - Axios uses `data` instead of `body`.
  - `Axios.get()` will override the the `method` option.
  - There is no `transport` option.
- [Response schema](https://axios-http.com/docs/res_schema):
  - Headers are turned into an object with lower cased names.
  - Response data is atomically parsed and can be accessed with `res.data`.
  - The response can't be stringified using `JSON.stringify()` because of `res.request`.

## Breaking Change

Given the `transport` issue, this PR does introduce a breaking change. Users that receive a PDF will have to change their code from this:
```js
oauthClient.makeApiCall({
  url: `${url}v3/company/${companyID}/invoice/${invoiceNumber}/pdf?minorversion=59`,
  headers:{'Content-Type': 'application/pdf','Accept':'application/pdf'},
  transport: popsicle.createTransport({type: 'buffer'})
})
```
To this:
```js
oauthClient.makeApiCall({
  url: `${url}v3/company/${companyID}/invoice/${invoiceNumber}/pdf?minorversion=59`,
  headers:{'Content-Type': 'application/pdf','Accept':'application/pdf'},
  responseType: 'arraybuffer'
})
```
In my opinion, switching to Axios is still worth it.

## Testing

The only things I use this package for are creating redirects and creating tokens, so those are the only things I've tested. Other users should test out the rest of the package before this PR is merged.