### PR TITLE
fix getting key from response of getKeyFromJWKsURI

### DIFF
--- a/src/OAuthClient.js
+++ b/src/OAuthClient.js
@@ -474,8 +474,7 @@ OAuthClient.prototype.getKeyFromJWKsURI = function getKeyFromJWKsURI(id_token, k
     .then((response) => {
       if (Number(response.status) !== 200) throw new Error('Could not reach JWK endpoint');
       // Find the key by KID
-      const responseBody = JSON.parse(response.body);
-      const key = responseBody.keys.find((el) => el.kid === kid);
+      const key = response.data.keys.find((el) => el.kid === kid);
       const cert = this.getPublicKey(key.n, key.e);
 
       return jwt.verify(id_token, cert);


### PR DESCRIPTION
I had an issue when trying to validate token

There was an error

"undefined" is not a valid JSON

The issue was in getting the "body" field from Axios response. But it hasn't a "body" field. It has a "data" field.
