### PR TITLE
enhancing makeApiCall to take endpoint uri only

### DIFF
--- a/src/OAuthClient.js
+++ b/src/OAuthClient.js
@@ -389,8 +389,23 @@ OAuthClient.prototype.makeApiCall = function makeApiCall(params) {
         ? Object.assign({}, baseHeaders, params.headers)
         : Object.assign({}, baseHeaders);
 
+    let baseURL = '';
+    let endpoint = '';
+    // backward compatibility: 
+    // checking to see if user has supplied the full url
+    if (params.url.startsWith(OAuthClient.environment.sandbox) || params.url.startsWith(OAuthClient.environment.production)) {
+      baseURL = params.url;
+      
+    } else {
+      baseURL = (this.environment && this.environment === 'production') ? OAuthClient.environment.production : OAuthClient.environment.sandbox;
+      // checking to see if user supplied the endpoint only and if it begins with a slash
+      // if it does, we remove the slash to avoid double slashes in the url
+      endpoint = params.url.startsWith('/') ? params.url.slice(1) : params.url;
+
+    }
+    
     const request = {
-      url: params.url,
+      url: baseURL + endpoint,
       method: params.method || 'GET',
       headers,
       responseType,

--- a/test/OAuthClientTest.js
+++ b/test/OAuthClientTest.js
@@ -306,12 +306,74 @@ describe('Tests for OAuthClient', () => {
           );
         });
     });
+    it('Make API Call in Sandbox Environment using relative endpoint - starting slash', () => {
+      oauthClient.environment = 'sandbox';
+      oauthClient.getToken().realmId = '12345';
+      // eslint-disable-next-line no-useless-concat
+      return oauthClient
+        .makeApiCall({
+          url:
+            '/v3/company/' + '12345' + '/companyinfo/' + '12345',
+        })
+        .then((authResponse) => {
+          expect(JSON.stringify(authResponse.json)).to.be.equal(
+            JSON.stringify(expectedMakeAPICall),
+          );
+        });
+    });
+    it('Make API Call in Sandbox Environment using relative endpoint - no starting slash', () => {
+      oauthClient.environment = 'sandbox';
+      oauthClient.getToken().realmId = '12345';
+      // eslint-disable-next-line no-useless-concat
+      return oauthClient
+        .makeApiCall({
+          url:
+            'v3/company/' + '12345' + '/companyinfo/' + '12345',
+        })
+        .then((authResponse) => {
+          expect(JSON.stringify(authResponse.json)).to.be.equal(
+            JSON.stringify(expectedMakeAPICall),
+          );
+        });
+    });
     it('Make API Call in Sandbox Environment with headers as parameters', () => {
       oauthClient.getToken().realmId = '12345';
       // eslint-disable-next-line no-useless-concat
       return oauthClient
         .makeApiCall({
           url: `https://sandbox-quickbooks.api.intuit.com/v3/company/12345/companyinfo/12345`,
+          headers: {
+            Accept: 'application/json',
+          },
+        })
+        .then((authResponse) => {
+          expect(JSON.stringify(authResponse.json)).to.be.equal(
+            JSON.stringify(expectedMakeAPICall),
+          );
+        });
+    });
+    it('Make API Call in Sandbox Environment with headers as parameters, relative endpoint path - starting slash', () => {
+      oauthClient.getToken().realmId = '12345';
+      // eslint-disable-next-line no-useless-concat
+      return oauthClient
+        .makeApiCall({
+          url: `/v3/company/12345/companyinfo/12345`,
+          headers: {
+            Accept: 'application/json',
+          },
+        })
+        .then((authResponse) => {
+          expect(JSON.stringify(authResponse.json)).to.be.equal(
+            JSON.stringify(expectedMakeAPICall),
+          );
+        });
+    });
+    it('Make API Call in Sandbox Environment with headers as parameters, relative endpoint path - no starting slash', () => {
+      oauthClient.getToken().realmId = '12345';
+      // eslint-disable-next-line no-useless-concat
+      return oauthClient
+        .makeApiCall({
+          url: `v3/company/12345/companyinfo/12345`,
           headers: {
             Accept: 'application/json',
           },
@@ -355,6 +417,36 @@ describe('Tests for OAuthClient', () => {
         .makeApiCall({
           url:
             'https://quickbooks.api.intuit.com/v3/company/' + '12345' + '/companyinfo/' + '12345',
+        })
+        .then((authResponse) => {
+          expect(JSON.stringify(authResponse.json)).to.be.equal(
+            JSON.stringify(expectedMakeAPICall),
+          );
+        });
+    });
+    it('Make API Call in Production Environment with relative endpoint path - starting slash', () => {
+      oauthClient.environment = 'production';
+      oauthClient.getToken().realmId = '12345';
+      // eslint-disable-next-line no-useless-concat
+      return oauthClient
+        .makeApiCall({
+          url:
+            '/v3/company/' + '12345' + '/companyinfo/' + '12345',
+        })
+        .then((authResponse) => {
+          expect(JSON.stringify(authResponse.json)).to.be.equal(
+            JSON.stringify(expectedMakeAPICall),
+          );
+        });
+    });
+    it('Make API Call in Production Environment with relative endpoing path - no starting slash', () => {
+      oauthClient.environment = 'production';
+      oauthClient.getToken().realmId = '12345';
+      // eslint-disable-next-line no-useless-concat
+      return oauthClient
+        .makeApiCall({
+          url:
+            'v3/company/' + '12345' + '/companyinfo/' + '12345',
         })
         .then((authResponse) => {
           expect(JSON.stringify(authResponse.json)).to.be.equal(
@@ -634,4 +726,53 @@ describe('Test Logging', () => {
     expect(oauthClient.logger.log.firstCall.args[0]).to.be.equal(level);
     expect(oauthClient.logger.log.firstCall.args[1]).to.be.equal(message + messageData);
   });
+});
+
+// must be last test as it changes the endpoints
+describe('Tests for OAuthClient to set custom Authorization URIs', () => {
+  describe('set the authorizationURIs', () => {
+    it('throws an error when no params provided', () => {
+      expect(() => { oauthClient.setAuthorizeURLs() }).to.throw("Provide the custom authorize URL's");
+    });
+    it('throws an error when no params provided', () => {
+      expect(() => { oauthClient.setAuthorizeURLs(null) }).to.throw("Provide the custom authorize URL's");
+    });
+    it('sets the Authorise urls to custom ones - sandbox', async (done) => {
+      const customURLs = {
+        authorizeEndpoint: "https://custom.Authorize.Endpoint",
+        tokenEndpoint: "https://custom.Token.Endpoint",
+        revokeEndpoint: "https://custom.Revoke.Endpoint",
+        userInfoEndpoint: "https://custom.User.Info.Endpoint",
+      }
+
+      oauthClient.environment = 'sandbox';
+      oauthClient.setAuthorizeURLs(customURLs);
+      done();
+      expect(OAuthClientTest.authorizeEndpoint).to.be.equal('https://custom.Authorize.Endpoint');
+      expect(OAuthClientTest.tokenEndpoint).to.be.equal('https://custom.Token.Endpoint');
+      expect(OAuthClientTest.revokeEndpoint).to.be.equal('https://custom.Revoke.Endpoint');
+      expect(OAuthClientTest.userinfo_endpoint_sandbox).to.be.equal('https://custom.User.Info.Endpoint');
+      expect(OAuthClientTest.userinfo_endpoint_production).to.be.equal('https://accounts.platform.intuit.com/v1/openid_connect/userinfo');
+
+    });
+    it('sets the Authorise urls to custom ones - production', async (done) => {
+      const customURLs = {
+        authorizeEndpoint: "https://custom.Authorize.Endpoint",
+        tokenEndpoint: "https://custom.Token.Endpoint",
+        revokeEndpoint: "https://custom.Revoke.Endpoint",
+        userInfoEndpoint: "https://custom.User.Info.Endpoint",
+      }
+
+      oauthClient.environment = 'production';
+      oauthClient.setAuthorizeURLs(customURLs);
+      done();
+      expect(OAuthClientTest.authorizeEndpoint).to.be.equal('https://custom.Authorize.Endpoint');
+      expect(OAuthClientTest.tokenEndpoint).to.be.equal('https://custom.Token.Endpoint');
+      expect(OAuthClientTest.revokeEndpoint).to.be.equal('https://custom.Revoke.Endpoint');
+      expect(OAuthClientTest.userinfo_endpoint_sandbox).to.be.equal('https://sandbox-accounts.platform.intuit.com/v1/openid_connect/userinfo');
+      expect(OAuthClientTest.userinfo_endpoint_production).to.be.equal('https://custom.User.Info.Endpoint');
+
+    });
+  });
+
 });


### PR DESCRIPTION
makeApiCall has been enhanced so that it makes a call to Quickbooks when:
- user provides the full prod or sandbox URL (backward compatibility)
- user provides the relative endpoint URL (/v3/company/...). It automatically pre-pends the sandbox or production URLs based on the environment property. This makes a seamless transition between sandbox and production.

Test cases for the change have been added

Test cases for setAuthorizeURLs have been added to increase the test coverage to the required level
BEFORE
=============================== Coverage summary ===============================
Statements   : 94.68% ( 731/772 )
Branches     : 82.82% ( 164/198 )
Functions    : 92.11% ( 187/203 )
Lines        : 95.46% ( 716/750 )
================================================================================

AFTER
=============================== Coverage summary ===============================
Statements   : 95.8% ( 799/834 )
Branches     : 85.57% ( 178/208 )
Functions    : 93.27% ( 208/223 )
Lines        : 96.54% ( 782/810 )
================================================================================