### PR TITLE
Fix package name in README and update to version 4.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ A Node.js client for Intuit's OAuth 2.0 implementation.
 ## Installation
 
 ```bash
-npm install oauth-jsclient
+npm install intuit-oauth
 ```
 
 ## Usage
 
 ```javascript
-const OAuthClient = require('oauth-jsclient');
+const OAuthClient = require('intuit-oauth');
 
 const oauthClient = new OAuthClient({
   clientId: 'your_client_id',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "intuit-oauth",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "Intuit Node.js client for OAuth2.0 and OpenIDConnect",
   "main": "./src/OAuthClient.js",
   "scripts": {


### PR DESCRIPTION
- Corrected npm install command from 'oauth-jsclient' to 'intuit-oauth'
- Fixed require statement in README to use correct package name
- Updated package version from 4.2.1 to 4.2.2 to match release branch
- Removed circular self-referencing dependency 'intuit-oauth' from dependencies