### PR TITLE
Fix: Correct Authorization header in makeApiCall method

### DIFF
--- a/src/OAuthClient.js
+++ b/src/OAuthClient.js
@@ -445,7 +445,7 @@ OAuthClient.prototype.makeApiCall = async function makeApiCall({ url, method, he
       const requestConfig = {
         method: method || 'GET',
         headers: {
-          ...this.authHeader(),
+          Authorization: `Bearer ${this.getToken().access_token}`,
           'Content-Type': 'application/json',
           'Accept': 'application/json',
           'User-Agent': OAuthClient.user_agent,


### PR DESCRIPTION
The makeApiCall method was incorrectly using spread operator on authHeader() which returns a string, not an object. This caused the headers object to be populated with numeric properties for each character of the base64 string, resulting in malformed HTTP headers and API call failures.

Fixed by properly setting the Authorization header with Bearer token: Authorization: `Bearer ${this.getToken().access_token}`

This matches the original 4.2.0 implementation and is consistent with other OAuth methods like getUserInfo().

Resolves issue reported by users after upgrading to 4.2.1 where API calls started failing due to incorrect header formatting.