### PR TITLE
Add x_refresh_token_lifetime_expires_in field and SalesTax scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.2.4](https://github.com/intuit/oauth-jsclient/tree/4.2.4)
+#### Features
+- Added `x_refresh_token_lifetime_expires_in` field to Token model to expose the five-year absolute refresh token lifetime
+  - Updated Token constructor, `getToken()`, `setToken()`, and `clearToken()` to support the new field
+  - Added `x-include-refresh-token-hard-expires-in: true` header to `createToken()`, `refresh()`, and `refreshUsingToken()` requests
+- Added `SalesTax` scope (`indirect-tax.tax-calculation.quickbooks`) to `OAuthClient.scopes`
+
 ## [4.2.3](https://github.com/intuit/oauth-jsclient/tree/4.2.3)
 #### Issues Fixed
 - **BREAKING CHANGE FIX**: Restored `response.data` property in `makeApiCall()` method for backward compatibility

--- a/src/OAuthClient.js
+++ b/src/OAuthClient.js
@@ -117,6 +117,7 @@ OAuthClient.scopes = {
   Dimensions: 'app-foundations.custom-dimensions.read',
   CustomFields: 'app-foundations.custom-field-definitions',
   TimeTracking: 'time-tracking.time-entry',
+  SalesTax: 'indirect-tax.tax-calculation.quickbooks',
   Profile: 'profile',
   Email: 'email',
   Phone: 'phone',
@@ -238,6 +239,7 @@ OAuthClient.prototype.createToken = function createToken(uri) {
         'Content-Type': AuthResponse._urlencodedContentType,
         Accept: AuthResponse._jsonContentType,
         'User-Agent': OAuthClient.user_agent,
+        'x-include-refresh-token-hard-expires-in': 'true',
       },
     };
 
@@ -279,6 +281,7 @@ OAuthClient.prototype.refresh = function refresh() {
         'Content-Type': AuthResponse._urlencodedContentType,
         Accept: AuthResponse._jsonContentType,
         'User-Agent': OAuthClient.user_agent,
+        'x-include-refresh-token-hard-expires-in': 'true',
       },
     };
 
@@ -321,6 +324,7 @@ OAuthClient.prototype.refreshUsingToken = function refreshUsingToken(refresh_tok
         'Content-Type': AuthResponse._urlencodedContentType,
         Accept: AuthResponse._jsonContentType,
         'User-Agent': OAuthClient.user_agent,
+        'x-include-refresh-token-hard-expires-in': 'true',
       },
     };
 

--- a/src/access-token/Token.js
+++ b/src/access-token/Token.js
@@ -38,6 +38,7 @@ function Token(params) {
   this.refresh_token = params.refresh_token || '';
   this.expires_in = params.expires_in || 0;
   this.x_refresh_token_expires_in = params.x_refresh_token_expires_in || 0;
+  this.x_refresh_token_lifetime_expires_in = params.x_refresh_token_lifetime_expires_in || 0;
   this.id_token = params.id_token || '';
   this.latency = params.latency || 60 * 1000;
   this.createdAt = params.createdAt || Date.now();
@@ -75,7 +76,8 @@ Token.prototype.tokenType = function tokenType() {
  *  access_token: *,
  *  expires_in: *,
  *  refresh_token: *,
- *  x_refresh_token_expires_in: *
+ *  x_refresh_token_expires_in: *,
+ *  x_refresh_token_lifetime_expires_in: *
  * }}
  */
 Token.prototype.getToken = function getToken() {
@@ -85,6 +87,7 @@ Token.prototype.getToken = function getToken() {
     expires_in: this.expires_in,
     refresh_token: this.refresh_token,
     x_refresh_token_expires_in: this.x_refresh_token_expires_in,
+    x_refresh_token_lifetime_expires_in: this.x_refresh_token_lifetime_expires_in,
     realmId: this.realmId,
     id_token: this.id_token,
     createdAt: this.createdAt,
@@ -102,6 +105,7 @@ Token.prototype.setToken = function setToken(tokenData) {
   this.token_type = tokenData.token_type;
   this.expires_in = tokenData.expires_in;
   this.x_refresh_token_expires_in = tokenData.x_refresh_token_expires_in;
+  this.x_refresh_token_lifetime_expires_in = tokenData.x_refresh_token_lifetime_expires_in || 0;
   this.id_token = tokenData.id_token || '';
   this.createdAt = tokenData.createdAt || Date.now();
   return this;
@@ -118,6 +122,7 @@ Token.prototype.clearToken = function clearToken() {
   this.token_type = '';
   this.expires_in = 0;
   this.x_refresh_token_expires_in = 0;
+  this.x_refresh_token_lifetime_expires_in = 0;
   this.id_token = '';
   this.createdAt = 0;
   return this;


### PR DESCRIPTION
## Changes

### New Token Field: `x_refresh_token_lifetime_expires_in`
- Added `x_refresh_token_lifetime_expires_in` to the Token model (constructor, `getToken()`, `setToken()`, `clearToken()`)
- This field exposes the five-year absolute refresh token lifetime countdown (in seconds)
- Added `x-include-refresh-token-hard-expires-in: true` header to all token endpoint requests (`createToken()`, `refresh()`, `refreshUsingToken()`) so the server returns this field in the response

### New Scope
- Added `SalesTax` scope (`indirect-tax.tax-calculation.quickbooks`) to `OAuthClient.scopes`

### Tests
- All 169 existing tests pass
- 100% coverage on Token.js

### Updated
- CHANGELOG.md with 4.2.4 entry