### PR TITLE
ci: add release-triggered npm publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,53 @@
+name: Publish to npm
+
+# Publishes the package to the npm registry when a GitHub Release is published.
+# Flow: create a Release (tag = version, e.g. 4.2.4) -> this workflow runs tests,
+# verifies the tag matches package.json, then runs `npm publish`.
+#
+# Requires repo secret: NPM_TOKEN
+#   - An npm Granular/Automation access token with publish rights on `intuit-oauth`.
+#   - Set at: Settings -> Secrets and variables -> Actions -> New repository secret.
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18.x
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm test
+        env:
+          CI: true
+
+      - name: Verify tag matches package.json version
+        run: |
+          PKG_VERSION="v$(node -p "require('./package.json').version")"
+          TAG="${GITHUB_REF_NAME}"
+          # Accept tag with or without a leading 'v'
+          if [ "$TAG" != "$PKG_VERSION" ] && [ "$TAG" != "${PKG_VERSION#v}" ]; then
+            echo "::error::Release tag ($TAG) does not match package.json version (${PKG_VERSION#v}). Aborting publish."
+            exit 1
+          fi
+          echo "Tag $TAG matches package.json version ${PKG_VERSION#v}."
+
+      - name: Publish to npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
Adds a GitHub Actions workflow that publishes `intuit-oauth` to npm automatically when a
GitHub Release is published. This removes the need for anyone to run `npm publish` locally
(and avoids local npm-login / 2FA / corporate-proxy friction).

## How it works
1. Bump `version` in `package.json` + update CHANGELOG (via a normal PR).
2. Create a GitHub Release with tag = the version (e.g. `4.2.4`).
3. This workflow runs on `release: published`:
   - installs deps, runs the full test suite (gate),
   - verifies the release tag matches `package.json` version,
   - runs `npm publish --access public`.

## One-time setup required (repo admin)
Add a repository secret **`NPM_TOKEN`**:
- Settings → Secrets and variables → Actions → New repository secret
- Value: an npm **Granular/Automation** access token with **publish** rights on `intuit-oauth`.

## Notes
- Uses Node 18 + current `actions/checkout@v4` / `setup-node@v4`.
- The tag-vs-version check prevents accidentally publishing a mismatched version.
- Does not change any runtime code.
