### PR TITLE
fix(npm): add files allowlist to prevent publishing logs/coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,14 @@
   "description": "Intuit Node.js client for OAuth2.0 and OpenIDConnect",
   "main": "./src/OAuthClient.js",
   "types": "./types/index.d.ts",
+  "files": [
+    "src/",
+    "types/",
+    "views/SDK.png",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE"
+  ],
   "scripts": {
     "start": "node index.js",
     "karma": "karma start karma.conf.js",


### PR DESCRIPTION
## Summary
Adds a `files` allowlist to `package.json` so the published npm tarball only contains
intended files. **This is a prerequisite for publishing 4.2.4 safely.**

## Why
A `npm publish --dry-run` showed the package was bundling the **entire working tree** —
61 files — including:
- `logs/oAuthClient-log.log` (a log file that must never ship)
- the whole `coverage/` directory (test-coverage HTML reports)
- test config (`mocha.opts`, etc.)

The repo's `.npmignore` didn't cover `logs/` or `coverage/`, and npm ignores `.gitignore`
when an `.npmignore` is present — so these slipped into the tarball.

## Fix
An explicit `files` allowlist is failsafe: only listed paths are ever published,
regardless of ignore-file gaps.

```json
"files": ["src/", "types/", "views/SDK.png", "README.md", "CHANGELOG.md", "LICENSE"]
```

## Result (verified via dry-run)
- Package goes from **61 files → 13 files**
- `logs/`, `coverage/`, `test/`, `sample/`, config files: **all excluded**
- Ships exactly: `src/`, `types/`, `views/SDK.png`, `README`, `CHANGELOG`, `LICENSE`, `package.json`
- No runtime code changed
